### PR TITLE
⚙️ Update all GitHub Action digests

### DIFF
--- a/.github/workflows/proton-backup-pr.yml
+++ b/.github/workflows/proton-backup-pr.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build Docker image for scanning
         id: build
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@cb8fc7586f9ad9441b20c33e0f6e8b1b58d8b4c6
         with:
           context: ./proton-drive-backup
           platforms: linux/amd64

--- a/.github/workflows/proton-backup-pr.yml
+++ b/.github/workflows/proton-backup-pr.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@032a4b3bda1b716928481836ac5bfe36e1feaad6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/proton-backup-pr.yml
+++ b/.github/workflows/proton-backup-pr.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security
         if: always() && hashFiles('trivy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@573acd9552f33577783abde4acb66a1058e762e5
+        uses: github/codeql-action/upload-sarif@0337c4c06e7e00d0d6e64396c13b9dc18dd6d8c5
         with:
           sarif_file: trivy-results.sarif
 

--- a/.github/workflows/proton-backup-pr.yml
+++ b/.github/workflows/proton-backup-pr.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435

--- a/.github/workflows/proton-backup-pr.yml
+++ b/.github/workflows/proton-backup-pr.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+        uses: docker/setup-buildx-action@1583c0f09d26c58c59d25b0eef29792b7ce99d9a
 
       - name: Extract metadata
         id: meta

--- a/.github/workflows/proton-backup-release.yml
+++ b/.github/workflows/proton-backup-release.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build and push multi-platform image
         id: push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@cb8fc7586f9ad9441b20c33e0f6e8b1b58d8b4c6
         with:
           context: ./proton-drive-backup
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/proton-backup-release.yml
+++ b/.github/workflows/proton-backup-release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@032a4b3bda1b716928481836ac5bfe36e1feaad6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/proton-backup-release.yml
+++ b/.github/workflows/proton-backup-release.yml
@@ -46,7 +46,7 @@ jobs:
           RELEASE_BRANCHES: main,master
 
       - name: Log in to Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
+        uses: docker/login-action@5b7b28b1cc417bbd34cd8c225a957c9ce9adf7f2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/proton-backup-release.yml
+++ b/.github/workflows/proton-backup-release.yml
@@ -101,7 +101,7 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62
         with:
           cosign-release: "v2.6.0"
 

--- a/.github/workflows/proton-backup-release.yml
+++ b/.github/workflows/proton-backup-release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+        uses: docker/setup-buildx-action@1583c0f09d26c58c59d25b0eef29792b7ce99d9a
 
       - name: Determine version bump from dependency changes
         id: version_bump

--- a/.github/workflows/proton-backup-release.yml
+++ b/.github/workflows/proton-backup-release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435

--- a/.github/workflows/proton-backup-release.yml
+++ b/.github/workflows/proton-backup-release.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security
         if: always() && hashFiles('trivy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@573acd9552f33577783abde4acb66a1058e762e5
+        uses: github/codeql-action/upload-sarif@0337c4c06e7e00d0d6e64396c13b9dc18dd6d8c5
         with:
           sarif_file: trivy-results.sarif
 

--- a/.github/workflows/proton-backup-security-scan.yml
+++ b/.github/workflows/proton-backup-security-scan.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Upload Trivy scan results to GitHub Security
       if: steps.latest-image.outputs.skip == 'false'
-      uses: github/codeql-action/upload-sarif@573acd9552f33577783abde4acb66a1058e762e5 
+      uses: github/codeql-action/upload-sarif@0337c4c06e7e00d0d6e64396c13b9dc18dd6d8c5 
       with:
         sarif_file: trivy-results.sarif
 

--- a/.github/workflows/proton-backup-security-scan.yml
+++ b/.github/workflows/proton-backup-security-scan.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 
+      uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 
 
     - name: Get latest image digest
       id: latest-image


### PR DESCRIPTION
## Summary
- Update actions/checkout digest to ff7abcd
- Update docker/build-push-action digest to cb8fc75  
- Update docker/login-action digest to 5b7b28b
- Update docker/metadata-action digest to 032a4b3
- Update docker/setup-buildx-action digest to 1583c0f
- Update github/codeql-action digest to 0337c4c
- Update sigstore/cosign-installer digest to d7543c9

This PR combines all pending Renovate digest updates for GitHub Actions into a single PR to reduce noise.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Chores:
- Update actions/checkout, docker/setup-buildx-action, docker/login-action, docker/metadata-action, docker/build-push-action, github/codeql-action/upload-sarif, and sigstore/cosign-installer to their latest commit digests