### PR TITLE
🔧 Fix Code Scanning baseline by adding Trivy to release workflow

### DIFF
--- a/.github/workflows/proton-backup-release.yml
+++ b/.github/workflows/proton-backup-release.yml
@@ -98,6 +98,19 @@ jobs:
             fi
           done
 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: 0
+
+      - name: Upload Trivy scan results to GitHub Security
+        if: always() && hashFiles('trivy-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@0337c4c06e7e00d0d6e64396c13b9dc18dd6d8c5
+        with:
+          sarif_file: trivy-results.sarif
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62


### PR DESCRIPTION
## Problem
Code Scanning Merge Protection is showing '1 configuration not found' because the release workflow doesn't include Trivy scanning to establish a baseline on the master branch.

## Root Cause  
- PR workflow runs Trivy and uploads SARIF results ✅
- Release workflow skips Trivy (was optimized for efficiency) ❌  
- Code Scanning can't compare PR vs master - no baseline exists ❌

## Solution
Added Trivy scanning to the release workflow:
- Scan the latest tag after it's created via retagging
- Upload SARIF results to GitHub Security to establish master baseline
- Same job name (build-and-scan) maintains consistency  

## Expected Result
- Code Scanning will have baseline results on master branch ✅
- Future PRs (like #14) can compare against this baseline ✅ 
- Trivy status will show proper NEW vs EXISTING vulnerability comparison ✅
- Auto-merge can function properly when no new vulnerabilities are introduced ✅

This is a critical fix needed for Code Scanning Merge Protection to function correctly.

## Summary by Sourcery

Add Trivy vulnerability scanning and SARIF upload to the release workflow to establish a Code Scanning baseline on the master branch

Bug Fixes:
- Include a Trivy scan of the latest image in the release workflow to provide baseline results

CI:
- Upload the Trivy scan SARIF report to GitHub Security in the release GitHub Actions workflow