### PR TITLE
🔧 Fix Code Scanning category mismatch

### DIFF
--- a/.github/workflows/proton-backup-pr.yml
+++ b/.github/workflows/proton-backup-pr.yml
@@ -89,6 +89,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@0337c4c06e7e00d0d6e64396c13b9dc18dd6d8c5
         with:
           sarif_file: trivy-results.sarif
+          category: trivy-container-scan
 
       - name: Comment PR with build summary
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd

--- a/.github/workflows/proton-backup-release.yml
+++ b/.github/workflows/proton-backup-release.yml
@@ -111,6 +111,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@0337c4c06e7e00d0d6e64396c13b9dc18dd6d8c5
         with:
           sarif_file: trivy-results.sarif
+          category: trivy-container-scan
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62


### PR DESCRIPTION
## Problem
Code Scanning shows 'configuration not found' because PR and release workflows use different analysis keys, preventing baseline comparison.

## Root Cause
- **PR workflow**: Analysis key was 
- **Release workflow**: Analysis key was 
- Code Scanning couldn't compare different analysis keys

## Solution
Added consistent  parameter to both workflows:
- Both now use the same arbitrary analysis key: 
- Code Scanning can now properly compare PR vs master baselines
- Resolves 'configuration not found' errors

## Expected Result
- ✅ Code Scanning will compare against consistent baselines
- ✅ No more 'configuration not found' errors  
- ✅ Auto-merge will function properly
- ✅ Renovate PRs can merge automatically when safe

This establishes the correct baseline for all future PRs.

## Summary by Sourcery

Unify the SARIF upload category in both PR and release workflows to enable proper Code Scanning baseline comparisons and resolve configuration-not-found errors

Bug Fixes:
- Resolve 'configuration not found' errors by matching analysis keys across PR and release workflows

CI:
- Add consistent category 'trivy-container-scan' parameter to CodeQL SARIF upload steps in both workflows