### PR TITLE
Enable encryption at rest for the jottacloud staging copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ make create-jotta-secret      # imperative secret creation for jottacloud-backup
 - **Traefik** as a hostNetwork DaemonSet for ingress on :80/:443 (no MetalLB)
 - **cert-manager** + Let's Encrypt with **Route53 DNS-01** solver; single wildcard `*.cynexia.net` cert
 - **local-path-provisioner** on the node's SSD (user volume mount)
+- **Encryption at rest** (2026-07-26): both pve3 NVMe partitions backing the Talos VM (vmdata LVM = OS disk/etcd, and the user volume) are LUKS2, auto-unlocked at host boot by the TPM via clevis (PCR 7, requires Secure Boot enabled). VM 100's disks point at `/dev/mapper/vmdata_crypt` LVs and `/dev/mapper/talos_ssd_crypt`. If VMs don't autostart after a pve3 boot, the TPM refused (firmware/SB change): `cryptsetup open` each volume with the recovery passphrases in 1Password (`op://Homelab/TPM/...`), `vgchange -ay`, `systemctl start pve-guests`, then re-run `clevis luks bind`. The jottacloud staging copy on the HDD pool is separately encrypted via rclone crypt (`DEST_REMOTE` in the workload ConfigMap).
 - **NFS CSI driver** for NFS-backed media from the Proxmox ZFS pool
 - **keel** for image auto-updates (with `keel.sh/match-tag: "true"` required on every Deployment — without it keel silently downgrades `:latest` via OCI version label)
 - **restic** nightly CronJob to Backblaze B2 (`b2:homelab-restic-d5e15f22`) backing up `/var/mnt/ssd/local-path-provisioner`. 7d/4w/6m retention.

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ create-jotta-secret: check-context
 	  --from-literal="S3_ACCESS_KEY=$$(op read 'op://Homelab/jottacloud-backup/S3_ACCESS_KEY')" \
 	  --from-literal="S3_SECRET_KEY=$$(op read 'op://Homelab/jottacloud-backup/S3_SECRET_KEY')" \
 	  --from-literal="RCLONE_CONFIG=$$(op read 'op://Homelab/jottacloud-backup/RCLONE_CONFIG')" \
+	  --from-literal="DEST_REMOTE_PASSWORD=$$(op read 'op://Homelab/jottacloud-backup/JOTTA_CRYPT_PASSWORD')" \
 	  --dry-run=client -o yaml | kubectl apply -f -
 
 # Apply Talos machine config patches to Omni. Each file under

--- a/homelab/talos/machineconfig-patches/400-homelab-user-volume-ssd.yaml
+++ b/homelab/talos/machineconfig-patches/400-homelab-user-volume-ssd.yaml
@@ -1,6 +1,9 @@
-# Talos user volume for the passthrough SSD (nvme0n1p2 on pve3, attached to
-# VM 100 as scsi1). Talos mounts this automatically at /var/mnt/ssd once the
-# disk is present and wiped of any existing filesystem signature.
+# Talos user volume for the SSD (nvme0n1p2 on pve3 — since 2026-07-26 wrapped
+# in host-side LUKS2 with TPM2 auto-unlock via clevis; VM 100's scsi1 points at
+# /dev/mapper/talos_ssd_crypt, not the raw partition). Talos mounts it
+# automatically at /var/mnt/ssd; the partition label u-ssd, PARTUUID and xfs
+# UUID were preserved across the encryption migration, so Talos sees the same
+# volume it always had.
 #
 # Disk selector matches the 500 GB virtio disk — the 64 GB virtio OS disk
 # (sda) is excluded by size. local-path-provisioner writes PV directories

--- a/homelab/workloads/jottacloud-backup.yaml
+++ b/homelab/workloads/jottacloud-backup.yaml
@@ -16,6 +16,16 @@ data:
   RCLONE_CONFIG_FILE: "/config/rclone.conf"
   JOTTA_REMOTE: "jotta"
   LOCAL_PATH: "/data/jotta"
+  # Encryption at rest: this one key is the whole switch. The container
+  # derives the crypt remote itself (always wrapping LOCAL_PATH, filename
+  # encryption off); the raw passphrase arrives via the DEST_REMOTE_PASSWORD
+  # key in jottacloud-backup-secrets (make create-jotta-secret). rclone.conf
+  # and the live Jottacloud token in it are never touched.
+  # Uncomment ONLY per the migration runbook: (1) image with DEST_REMOTE
+  # support is live, (2) secret has DEST_REMOTE_PASSWORD, (3) the existing
+  # plaintext copy has been migrated to ciphertext (see
+  # docs/superpowers/specs/2026-07-26-encryption-at-rest-design.md §5).
+  DEST_REMOTE: "jottacrypt"
   KOPIA_CONFIG_FILE: "/config/kopia.config"
   KOPIA_CACHE_DIR: "/config/cache"
   KOPIA_LOG_DIR: "/data/logs/kopia"
@@ -104,7 +114,9 @@ spec:
               type: RuntimeDefault
           containers:
             - name: backup
-              image: ghcr.io/mnbf9rca/jottacloud-backup:latest
+              # Migration-window digest pin (runbook step 4) — revert to :latest
+              # after a few stable encrypted runs (runbook step 8)
+              image: ghcr.io/mnbf9rca/jottacloud-backup@sha256:effc2553f5b9969e50be5ba9f19a4603ec7265793367a45a88c4e43b8115e2c3
               imagePullPolicy: Always
               securityContext:
                 allowPrivilegeEscalation: false

--- a/homelab/workloads/jottacloud-backup.yaml
+++ b/homelab/workloads/jottacloud-backup.yaml
@@ -114,9 +114,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: backup
-              # Migration-window digest pin (runbook step 4) — revert to :latest
-              # after a few stable encrypted runs (runbook step 8)
-              image: ghcr.io/mnbf9rca/jottacloud-backup@sha256:effc2553f5b9969e50be5ba9f19a4603ec7265793367a45a88c4e43b8115e2c3
+              image: ghcr.io/mnbf9rca/jottacloud-backup:latest
               imagePullPolicy: Always
               securityContext:
                 allowPrivilegeEscalation: false


### PR DESCRIPTION
## What

Turns on contents-only encryption (rclone crypt, `filename_encryption=off`) for the Jottacloud staging copy on the pool, so a stolen or disposed HDD yields no readable personal data.

- `homelab/workloads/jottacloud-backup.yaml`: uncomment `DEST_REMOTE: "jottacrypt"` — the entire switch; the container derives the crypt remote itself (always wrapping `LOCAL_PATH`). Image temporarily pinned to the mnbf9rca/jottacloud-backup#69 release digest for the migration window (revert-to-`:latest` commit follows after a few stable runs).
- `Makefile`: one `--from-literal` line adding `DEST_REMOTE_PASSWORD` to `create-jotta-secret`, sourced from the frozen `JOTTA_CRYPT_PASSWORD` 1Password field. `RCLONE_CONFIG` untouched (hash-verified identical before/after — the live Jottacloud OAuth token is never rewritten).

## Migration state at PR time

Executed per the local runbook: CronJob suspended + quiesced; existing 24G plaintext encrypted in place on pve3 (`cryptcheck`: 0 differences, 6183 files); sentinel latch + key canary pre-seeded; ownership 1999:1999 verified; decrypt spot-check passed. Plaintext copy retained at `jotta-plain` until post-verification manual deletion.

Container-side guardrails (upstream PR #69, merged): key canary blocks any passphrase/mode drift before sync; sentinel blocks plaintext-mode syncs into the ciphertext dir; post-sync count verification catches residue; kopia backs up ciphertext unchanged.